### PR TITLE
add config files to use flow, babel and eslint

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,5 @@
+{
+  "plugins": [ "transform-flow-strip-types" ],
+  "presets": [ "es2015" ]
+}
+

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,11 @@
+{
+  "parser": "babel-eslint",
+  "extends": [ "plugin:flowtype/recommended" ],
+  "plugins": [ "flowtype" ],
+  "settings": {
+    "flowtype": {
+      "onlyFilesWithFlowAnnotation": true
+    }
+  }
+}
+

--- a/.flowconfig
+++ b/.flowconfig
@@ -1,0 +1,9 @@
+[ignore]
+.*/node_modules/.*
+./dst/.*
+
+[include]
+
+[libs]
+
+[options]

--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ jspm_packages
 
 # Optional REPL history
 .node_repl_history
+
+# Project specific
+dst

--- a/package.json
+++ b/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "my-flow-project",
+  "version": "1.0.0",
+  "devDependencies": {
+    "babel": "^6.23.0",
+    "babel-cli": "^6.24.1",
+    "babel-core": "^6.24.1",
+    "babel-eslint": "^7.2.3",
+    "babel-plugin-transform-flow-strip-types": "^6.22.0",
+    "babel-preset-es2015": "^6.24.1",
+    "eslint": "^3.19.0",
+    "eslint-plugin-flowtype": "^2.32.1",
+    "flow-bin": "^0.41.0"
+  },
+  "scripts": {
+    "flow": "flow",
+    "babel": "babel src --out-dir dst"
+  }
+}

--- a/src/flow-guide/tutorial/00-basics/00-untyped-a.js
+++ b/src/flow-guide/tutorial/00-basics/00-untyped-a.js
@@ -1,0 +1,21 @@
+const CONVERSION_TABLE = {
+  m: {
+    km: (m) => m / 1000,
+    mi: (m) => m * 0.000621371,
+  },
+};
+
+// Converts a value from one unit to another
+// by using our internal totally awesome conversion
+// table. Returns a new UnitValue object.
+function convertUnit(from, to, value) {
+  const transform = CONVERSION_TABLE[from][to];
+
+  return transform(value);
+}
+
+// Will return 1
+convertUnit('m', 'km', 1000);
+
+// Will return ?
+convertUnit('cm', 'm', 100);

--- a/src/flow-guide/tutorial/00-basics/01-untyped-b.js
+++ b/src/flow-guide/tutorial/00-basics/01-untyped-b.js
@@ -1,0 +1,25 @@
+const METER = 'm';
+const KILOMETER = 'km';
+const MILE = 'mi';
+
+const CONVERSION_TABLE = {
+  [METER]: {
+    [KILOMETER]: (m) => m / 1000,
+    [MILE]: (m) => m * 0.000621371,
+  },
+};
+
+// Converts a value from one unit to another
+// by using our internal totally awesome conversion
+// table. Returns a new UnitValue object.
+function convertUnit(from, to, value) {
+  const transform = CONVERSION_TABLE[from][to];
+
+  return transform(value);
+}
+
+// So now we are using constants, which might be safer with ESlint
+convertUnit(METER, KILOMETER, 1000)
+
+// But this doesn't protect us from misuse and will throw an 'undefined' error
+convertUnit('cm', 'm', 100);

--- a/src/flow-guide/tutorial/00-basics/02-basic-typed.js
+++ b/src/flow-guide/tutorial/00-basics/02-basic-typed.js
@@ -1,0 +1,21 @@
+/* @flow */
+
+const CONVERSION_TABLE = {
+  m: {
+    km: (m) => m / 1000,
+    mi: (m) => m * 0.000621371,
+  }
+};
+
+function convertUnit(from: string, to: string, value: number): number {
+  const transform = CONVERSION_TABLE[from][to];
+
+  return transform(value);
+}
+
+// Will return 1
+convertUnit('m', 'km', 1000);
+
+// This error goes unnoticed during development...
+// Especially hard to debug if you use variables for 'from' & 'to'
+convertUnit('cm', 'm', 100);


### PR DESCRIPTION
flow, babel が動作するようにしてみた。
```
# for running flow
$ npm run flow

# for running babel
$ npm run babel
```

参考サイト:
- [ryyppy/flow-guide: The definitive guide for using Flow static JavaScript type checker (https://flowtype.org)](https://github.com/ryyppy/flow-guide)